### PR TITLE
Add ok-to-prod label to the list of labels that can be added via comment

### DIFF
--- a/manifests/prow/common/configmaps/plugins.yaml
+++ b/manifests/prow/common/configmaps/plugins.yaml
@@ -163,6 +163,7 @@ data:
         - env/stg-saas
         - env/pro-base
         - env/pro-saas
+        - ok-to-prod
 
     blunderbuss:
       # ExcludeApprovers controls whether approvers are considered to be


### PR DESCRIPTION



#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

Engineering team cannot add the label via comment, and since they have read permission, they need to be able to use comments to interacts with PRs.


#### Additional documentation e.g., usage docs, etc.:

NA
